### PR TITLE
Optimized Blessing Auto Assignments

### DIFF
--- a/PallyPower.lua
+++ b/PallyPower.lua
@@ -4049,6 +4049,9 @@ function PallyPower:BuffSelectionOptimized(pallys, class, prioritylist)
 	end
 
 	for buff, buffer in pairs(assignments) do
+		if PallyPower_Assignments[buffer] == nil then
+			PallyPower_Assignments[buffer] = {}
+		end
 		PallyPower_Assignments[buffer][class] = buff
 		self:TankNormalBlessingOverride(buff, class, buffer)
 	end

--- a/PallyPower.toc
+++ b/PallyPower.toc
@@ -31,4 +31,5 @@ locale\zhTW.lua
 PallyPower.lua
 PallyPowerValues.lua
 PallyPowerOptions.lua
+PallyPowerAutoAssignment.lua
 PallyPower_Wrath.xml

--- a/PallyPowerAutoAssignment.lua
+++ b/PallyPowerAutoAssignment.lua
@@ -292,5 +292,15 @@ function PallyPowerAutoAssignments(pallys, preferred_buffs, orig_buffers)
     assignments[buff] = buffer
   end
 
+  -- make sure a pally is assigned to only one buff, return nil otherwise
+  local verify = {}
+  for _, buffer  in pairs(assignments) do
+    if table_contains(verify, buffer) then
+      return nil
+    end
+
+    table.insert(verify, buffer)
+  end
+
   return assignments
 end

--- a/PallyPowerAutoAssignment.lua
+++ b/PallyPowerAutoAssignment.lua
@@ -1,0 +1,211 @@
+PallyPowerAutoAssignmentBuffs = PallyPower.isWrath and {
+  wisdom = 1,
+  might = 2,
+  kings = 3,
+  sanc = 4,
+} or {
+  wisdom = 1,
+  might = 2,
+  kings = 3,
+  salv = 4,
+  light = 5,
+  sanc = 6,
+  sac = 7,
+}
+
+local kings = PallyPowerAutoAssignmentBuffs.kings
+local sanc = PallyPowerAutoAssignmentBuffs.sanc
+local wisdom = PallyPowerAutoAssignmentBuffs.wisdom
+local might = PallyPowerAutoAssignmentBuffs.might
+
+local function table_contains(t, val)
+  for _, v in pairs(t) do
+    if v == val then
+      return true
+    end
+  end
+  return false
+end
+
+local function get_preferred_imp_buff(buff_prio)
+  for _, buff in ipairs(buff_prio) do
+    if buff == wisdom or buff == might then
+      return buff
+    end
+  end
+
+  return nil
+end
+
+local function get_buffer_skill(buffer, buff_buffers)
+  for _, b in ipairs(buff_buffers) do
+    if b.pallyname == buffer then
+      return b.skill
+    end
+  end
+
+  return 0
+end
+
+local function recalc_buff_skills(pallys, orig_buffers)
+  local new_buffers = {}
+  for buff, buffers in ipairs(orig_buffers) do
+    new_buffers[buff] = {}
+    for _, buffer in ipairs(buffers) do
+      if table_contains(pallys, buffer.pallyname) then
+        local effective_skill = buffer.skill
+        if buff == PallyPowerAutoAssignmentBuffs.salv or buff == PallyPowerAutoAssignmentBuffs.light then
+          effective_skill = 1
+        end
+        table.insert(new_buffers[buff], {pallyname = buffer.pallyname, skill = effective_skill})
+      end
+    end
+  end
+
+  return new_buffers
+end
+
+local function calc_imp_skills(pallys, buffers, buff_prio)
+  local pref_imp_buff = get_preferred_imp_buff(buff_prio)
+  local imp_skills = {}
+  for _, pally in ipairs(pallys) do
+    local wisdom_skill = get_buffer_skill(pally, buffers[wisdom])
+    local might_skill = get_buffer_skill(pally, buffers[might])
+    if pref_imp_buff == wisdom then
+      wisdom_skill = wisdom_skill * 2
+    else
+      might_skill = might_skill * 2
+    end
+
+    imp_skills[pally] = wisdom_skill + might_skill
+  end
+
+  return imp_skills
+end
+
+local function filter_available(buff_prio, available_buffers)
+  local available_buffs = {}
+  for _, buff in ipairs(buff_prio) do
+    if #available_buffers[buff] > 0 then
+      table.insert(available_buffs, buff)
+    end
+  end
+
+  return available_buffs
+end
+
+local function get_buff_position(buff_prio, buff)
+  for i, b in ipairs(buff_prio) do
+    if b == buff then
+      return i
+    end
+  end
+
+  return -1
+end
+
+local function will_get_buff(buff, buff_prio, num_pallys)
+  local buff_pos = get_buff_position(buff_prio, buff)
+  if buff_pos == -1 then
+    return false
+  end
+
+  return buff_pos <= num_pallys
+end
+
+local function get_most_skilled_buffer(buff_buffers, current_assignments)
+  local most_skilled
+  for _, candidate in ipairs(buff_buffers) do
+    if not table_contains(current_assignments, candidate.pallyname) then
+      if most_skilled == nil or candidate.skill > most_skilled.skill then
+        most_skilled = candidate
+      end
+    end
+  end
+
+  if most_skilled ~= nil then
+    return most_skilled.pallyname
+  end
+
+  return nil
+end
+
+local function get_least_skilled_imp_buffer(buff_buffers, imp_buffers, current_assignments)
+  local least_skilled
+  for _, candidate in ipairs(buff_buffers) do
+    if not table_contains(current_assignments, candidate.pallyname) then
+      if least_skilled == nil or imp_buffers[candidate.pallyname] < imp_buffers[least_skilled] then
+        least_skilled = candidate.pallyname
+      end
+    end
+  end
+
+  return least_skilled
+end
+
+local function assign_talented_buffers(buff_prio, buffers, num_pallys, imp_buffers)
+  -- talented buffs, so if they are needed they will get special treatment
+  local needs_kings = will_get_buff(kings, buff_prio, num_pallys)
+  local needs_sanc = will_get_buff(sanc, buff_prio, num_pallys)
+  local assignments = {}
+
+  if needs_kings and needs_sanc then
+    if #buffers[kings] == 1 and #buffers[sanc] == 1 then
+      if buffers[kings][1].pallyname == buffers[sanc][1].pallyname then
+        if get_buff_position(buff_prio, kings) < get_buff_position(buff_prio, sanc) then
+          assignments[kings] = get_least_skilled_imp_buffer(buffers[kings], imp_buffers, assignments)
+        else
+          assignments[sanc] = get_least_skilled_imp_buffer(buffers[sanc], imp_buffers, assignments)
+        end
+      else
+        assignments[kings] = get_least_skilled_imp_buffer(buffers[kings], imp_buffers, assignments)
+        assignments[sanc] = get_least_skilled_imp_buffer(buffers[sanc], imp_buffers, assignments)
+      end
+    elseif #buffers[kings] > 1 and #buffers[sanc] == 1 then
+      assignments[sanc] = get_least_skilled_imp_buffer(buffers[sanc], imp_buffers, assignments)
+      assignments[kings] = get_least_skilled_imp_buffer(buffers[kings], imp_buffers, assignments)
+    else
+      -- #buffers[kings] == 1 and #buffers[sanc] > 1 or both > 1.
+      -- either way we can assign kings first and there will be someone to do sanc
+      assignments[kings] = get_least_skilled_imp_buffer(buffers[kings], imp_buffers, assignments)
+      assignments[sanc] = get_least_skilled_imp_buffer(buffers[sanc], imp_buffers, assignments)
+    end
+  elseif needs_kings and not needs_sanc then
+    assignments[kings] = get_least_skilled_imp_buffer(buffers[kings], imp_buffers, assignments)
+  elseif needs_sanc and not needs_kings then
+    assignments[sanc] = get_least_skilled_imp_buffer(buffers[sanc], imp_buffers, assignments)
+  end
+
+  return assignments
+end
+
+function PallyPowerAutoAssignments(pallys, preferred_buffs, orig_buffers)
+  local buffers = recalc_buff_skills(pallys, orig_buffers)
+  local buff_prio = filter_available(preferred_buffs, buffers)
+  local imp_skills = calc_imp_skills(pallys, buffers, buff_prio)
+  local assignments = {}
+  local num_assignments = 0
+
+  for buff, buffer in pairs(assign_talented_buffers(buff_prio, buffers, #pallys, imp_skills)) do
+    assignments[buff] = buffer
+    num_assignments = num_assignments + 1
+  end
+
+  for _, buff in ipairs(buff_prio) do
+    if num_assignments < #pallys and assignments[buff] == nil then
+      local buffer
+      if buff == might or buff == wisdom then
+        buffer = get_most_skilled_buffer(buffers[buff], assignments)
+      else
+        buffer = get_least_skilled_imp_buffer(buffers[buff], imp_skills, assignments)
+      end
+
+      if buffer ~= nil then
+        assignments[buff] = buffer
+        num_assignments = num_assignments + 1
+      end
+    end
+  end
+
+  return assignments
+end

--- a/PallyPowerAutoAssignment.lua
+++ b/PallyPowerAutoAssignment.lua
@@ -170,7 +170,6 @@ local function get_most_skilled_buffer(buffers, buff, assignments)
   for _, candidate in ipairs(buffers[buff]) do
     if not is_talented_buff(get_assigned_buff(candidate.pallyname, assignments)) then
       table.insert(candidates, candidate)
-      most_skilled = candidate
     end
   end
 
@@ -184,7 +183,7 @@ local function get_most_skilled_buffer(buffers, buff, assignments)
   table.sort(candidates, function(a, b) return a.skill > b.skill  end)
   local most_skilled = candidates[1]
 
-  -- swapping only works assuming both players can do both buffs
+  -- swapping only works assuming both players can do both buffs. true because we only do this for untalented buffs
   if is_improvable_buff(buff) and table_contains(assignments, most_skilled.pallyname) then
     local current = get_assigned_buff(most_skilled.pallyname, assignments)
     local skill_at_current = get_buffer_skill(most_skilled.pallyname, buffers[current])

--- a/PallyPowerAutoAssignment.lua
+++ b/PallyPowerAutoAssignment.lua
@@ -10,7 +10,6 @@ PallyPowerAutoAssignmentBuffs = PallyPower.isWrath and {
   salv = 4,
   light = 5,
   sanc = 6,
-  sac = 7,
 }
 
 local kings = PallyPowerAutoAssignmentBuffs.kings

--- a/PallyPowerAutoAssignment.lua
+++ b/PallyPowerAutoAssignment.lua
@@ -27,9 +27,46 @@ local function table_contains(t, val)
   return false
 end
 
+local function is_talented_buff(buff)
+  return table_contains({kings, sanc}, buff)
+end
+
+local function is_improvable_buff(buff)
+  return table_contains({might, wisdom}, buff)
+end
+
 local function get_preferred_imp_buff(buff_prio)
   for _, buff in ipairs(buff_prio) do
     if buff == wisdom or buff == might then
+      return buff
+    end
+  end
+
+  return nil
+end
+
+local function get_remaining_buffs(pallys, preferred_buffs, assignments)
+  local remaining_buffs = {}
+  local assigned_buffs = {}
+  local num_assignments = 0
+  for buff, _ in pairs(assignments) do
+    table.insert(assigned_buffs, buff)
+    num_assignments = num_assignments + 1
+  end
+
+  for _, buff in ipairs(preferred_buffs) do
+    if num_assignments < #pallys and not table_contains(assigned_buffs, buff) then
+      table.insert(remaining_buffs, buff)
+      num_assignments = num_assignments + 1
+    end
+  end
+
+  return remaining_buffs
+end
+
+local function get_assigned_buff(buffer, assignments)
+  for buff, b in pairs(assignments) do
+    if b == buffer then
       return buff
     end
   end
@@ -65,8 +102,7 @@ local function recalc_buff_skills(pallys, orig_buffers)
   return new_buffers
 end
 
-local function calc_imp_skills(pallys, buffers, buff_prio)
-  local pref_imp_buff = get_preferred_imp_buff(buff_prio)
+local function calc_imp_skills(pallys, buffers, pref_imp_buff)
   local imp_skills = {}
   for _, pally in ipairs(pallys) do
     local wisdom_skill = get_buffer_skill(pally, buffers[wisdom])
@@ -94,6 +130,17 @@ local function filter_available(buff_prio, available_buffers)
   return available_buffs
 end
 
+local function remove_talented(buff_prio)
+  local untalented = {}
+  for _, buff in ipairs(buff_prio) do
+    if buff ~= kings and buff ~= sanc then
+      table.insert(untalented, buff)
+    end
+  end
+
+  return untalented
+end
+
 local function get_buff_position(buff_prio, buff)
   for i, b in ipairs(buff_prio) do
     if b == buff then
@@ -113,21 +160,58 @@ local function will_get_buff(buff, buff_prio, num_pallys)
   return buff_pos <= num_pallys
 end
 
-local function get_most_skilled_buffer(buff_buffers, current_assignments)
-  local most_skilled
-  for _, candidate in ipairs(buff_buffers) do
-    if not table_contains(current_assignments, candidate.pallyname) then
-      if most_skilled == nil or candidate.skill > most_skilled.skill then
-        most_skilled = candidate
-      end
+local function get_most_skilled_buffer(buffers, buff, assignments)
+  local candidates = {}
+  for _, candidate in ipairs(buffers[buff]) do
+    if not is_talented_buff(get_assigned_buff(candidate.pallyname, assignments)) then
+      table.insert(candidates, candidate)
+      most_skilled = candidate
     end
   end
 
-  if most_skilled ~= nil then
-    return most_skilled.pallyname
+
+  if #candidates == 0 then
+    return nil
+  elseif #candidates == 1 then
+    return candidates[1].pallyname
   end
 
-  return nil
+  table.sort(candidates, function(a, b) return a.skill > b.skill  end)
+  local most_skilled = candidates[1]
+
+  -- swapping only works assuming both players can do both buffs
+  if is_improvable_buff(buff) and table_contains(assignments, most_skilled.pallyname) then
+    local current = get_assigned_buff(most_skilled.pallyname, assignments)
+    local skill_at_current = get_buffer_skill(most_skilled.pallyname, buffers[current])
+
+    -- find someone unassigned that has the same skill at the current buff
+    local backup_buffer
+    for _, candidate in ipairs(buffers[current]) do
+      if not table_contains(assignments, candidate.pallyname) and candidate.skill == skill_at_current then
+        backup_buffer = candidate
+      end
+    end
+
+    if backup_buffer ~= nil then
+      assignments[current] = backup_buffer.pallyname
+      return most_skilled.pallyname
+    end
+
+    local next_available_most_skilled
+    for i = 2, #candidates, 1 do
+      if next_available_most_skilled == nil and not table_contains(assignments, candidates[i].pallyname) then
+        next_available_most_skilled = candidates[i]
+      end
+    end
+
+    if next_available_most_skilled == nil then
+      return nil
+    end
+
+    most_skilled = next_available_most_skilled
+  end
+
+  return most_skilled.pallyname
 end
 
 local function get_least_skilled_imp_buffer(buff_buffers, imp_buffers, current_assignments)
@@ -182,29 +266,30 @@ end
 function PallyPowerAutoAssignments(pallys, preferred_buffs, orig_buffers)
   local buffers = recalc_buff_skills(pallys, orig_buffers)
   local buff_prio = filter_available(preferred_buffs, buffers)
-  local imp_skills = calc_imp_skills(pallys, buffers, buff_prio)
+  local pref_imp_buff = get_preferred_imp_buff(buff_prio)
+  local imp_skills = calc_imp_skills(pallys, buffers, buff_prio, pref_imp_buff)
   local assignments = {}
-  local num_assignments = 0
 
   for buff, buffer in pairs(assign_talented_buffers(buff_prio, buffers, #pallys, imp_skills)) do
     assignments[buff] = buffer
-    num_assignments = num_assignments + 1
   end
 
-  for _, buff in ipairs(buff_prio) do
-    if num_assignments < #pallys and assignments[buff] == nil then
-      local buffer
-      if buff == might or buff == wisdom then
-        buffer = get_most_skilled_buffer(buffers[buff], assignments)
-      else
-        buffer = get_least_skilled_imp_buffer(buffers[buff], imp_skills, assignments)
-      end
+  buff_prio = remove_talented(buff_prio)
+  buff_prio = get_remaining_buffs(pallys, buff_prio, assignments)
 
-      if buffer ~= nil then
-        assignments[buff] = buffer
-        num_assignments = num_assignments + 1
-      end
+  for _, buff in ipairs(buff_prio) do
+    local buffer
+    if is_improvable_buff(buff) then
+      buffer = get_most_skilled_buffer(buffers, buff, assignments)
+    else
+      buffer = get_least_skilled_imp_buffer(buffers[buff], imp_skills, assignments)
     end
+
+    if buffer == nil then
+      return nil
+    end
+
+    assignments[buff] = buffer
   end
 
   return assignments

--- a/PallyPower_TBC.toc
+++ b/PallyPower_TBC.toc
@@ -31,4 +31,5 @@ locale\zhTW.lua
 PallyPower.lua
 PallyPowerValues.lua
 PallyPowerOptions.lua
+PallyPowerAutoAssignment.lua
 PallyPower_TBC.xml

--- a/PallyPower_Vanilla.toc
+++ b/PallyPower_Vanilla.toc
@@ -31,4 +31,5 @@ locale\zhTW.lua
 PallyPower.lua
 PallyPowerValues.lua
 PallyPowerOptions.lua
+PallyPowerAutoAssignment.lua
 PallyPower_Vanilla.xml

--- a/PallyPower_Wrath.toc
+++ b/PallyPower_Wrath.toc
@@ -31,4 +31,5 @@ locale\zhTW.lua
 PallyPower.lua
 PallyPowerValues.lua
 PallyPowerOptions.lua
+PallyPowerAutoAssignment.lua
 PallyPower_Wrath.xml

--- a/test_auto_assignments_tbc.lua
+++ b/test_auto_assignments_tbc.lua
@@ -103,3 +103,102 @@ available_buffers[kings] = {{pallyname = "ret", skill = 1}}
 assignments = PallyPowerAutoAssignments(pallys, {kings, sanc}, available_buffers)
 assert(assignments[kings] == "ret")
 assert(assignments[sanc] == "prot")
+
+pallys = {"prot", "ret"}
+available_buffers = {
+  [wisdom] = {
+    {pallyname = "prot", skill = 7},
+    {pallyname = "ret", skill = 7},
+  },
+  [might] = {
+    {pallyname = "prot", skill = 13},
+    {pallyname = "ret", skill = 8},
+  },
+  [kings] = {
+    {pallyname = "prot", skill = 1},
+  },
+  [salv] = {
+    {pallyname = "prot", skill = 1},
+    {pallyname = "ret", skill = 1},
+  },
+  [light] = {
+    {pallyname = "prot", skill = 1},
+    {pallyname = "ret", skill = 1},
+  },
+  [sanc] = {
+    {pallyname = "prot", skill = 1},
+  },
+}
+
+assignments = PallyPowerAutoAssignments(pallys, {wisdom, might}, available_buffers)
+assert(assignments[might] == "prot")
+assert(assignments[wisdom] == "ret")
+-- different order, same outcome
+assignments = PallyPowerAutoAssignments(pallys, {might, wisdom}, available_buffers)
+assert(assignments[might] == "prot")
+assert(assignments[wisdom] == "ret")
+
+available_buffers[kings] = {}
+assignments = PallyPowerAutoAssignments(pallys, {might, kings, sanc}, available_buffers)
+assert(assignments[might] == "ret")
+assert(assignments[sanc] == "prot")
+
+pallys = {"holy1", "holy2", "prot1", "prot2", "ret"}
+available_buffers = {
+  [wisdom] = {
+    {pallyname = "holy1", skill = 9},
+    {pallyname = "holy2", skill = 9},
+    {pallyname = "prot1", skill = 7},
+    {pallyname = "prot2", skill = 7},
+    {pallyname = "ret", skill = 7},
+  },
+  [might] = {
+    {pallyname = "holy1", skill = 13},
+    {pallyname = "holy2", skill = 12},
+    {pallyname = "prot1", skill = 8},
+    {pallyname = "prot2", skill = 9},
+    {pallyname = "ret", skill = 8},
+  },
+  [kings] = {
+    {pallyname = "holy1", skill = 1},
+    {pallyname = "prot1", skill = 1},
+    {pallyname = "ret", skill = 1}
+  },
+  [salv] = {
+    {pallyname = "holy1", skill = 1},
+    {pallyname = "holy2", skill = 1},
+    {pallyname = "prot1", skill = 1},
+    {pallyname = "prot2", skill = 1},
+    {pallyname = "ret", skill = 1},
+  },
+  [light] = {
+    {pallyname = "holy1", skill = 1},
+    {pallyname = "holy2", skill = 1},
+    {pallyname = "prot1", skill = 1},
+    {pallyname = "prot2", skill = 1},
+    {pallyname = "ret", skill = 1},
+  },
+  [sanc] = {
+    {pallyname = "prot1", skill = 1},
+  }
+}
+assignments = PallyPowerAutoAssignments(pallys, {salv, kings, wisdom, might, sanc, light}, available_buffers)
+assert(assignments[salv] == "prot2")
+assert(assignments[kings] == "ret")
+assert(assignments[wisdom] == "holy2")
+assert(assignments[might] == "holy1")
+assert(assignments[sanc] == "prot1")
+
+available_buffers[sanc][1].pallyname = "prot2"
+assignments = PallyPowerAutoAssignments(pallys, {salv, kings, wisdom, might, sanc, light}, available_buffers)
+assert((assignments[salv] == "prot1" and assignments[kings] == "ret") or (assignments[salv] == "ret" and assignments[kings] == "prot1"))
+assert(assignments[wisdom] == "holy2")
+assert(assignments[might] == "holy1")
+assert(assignments[sanc] == "prot2")
+
+-- different order, same outcome
+assignments = PallyPowerAutoAssignments(pallys, {sanc, salv, might, wisdom, kings, light}, available_buffers)
+assert((assignments[salv] == "prot1" and assignments[kings] == "ret") or (assignments[salv] == "ret" and assignments[kings] == "prot1"))
+assert(assignments[wisdom] == "holy2")
+assert(assignments[might] == "holy1")
+assert(assignments[sanc] == "prot2")

--- a/test_auto_assignments_tbc.lua
+++ b/test_auto_assignments_tbc.lua
@@ -1,13 +1,12 @@
 PallyPower = {isWrath = false}
-
 dofile ("./PallyPowerAutoAssignment.lua")
 
-local kings = PallyPowerAutoAssignmentBuffs.kings
-local sanc = PallyPowerAutoAssignmentBuffs.sanc
-local wisdom = PallyPowerAutoAssignmentBuffs.wisdom
-local might = PallyPowerAutoAssignmentBuffs.might
-local salv = PallyPowerAutoAssignmentBuffs.salv
-local light = PallyPowerAutoAssignmentBuffs.light
+local wisdom = 1
+local might = 2
+local kings = 3
+local salv = 4
+local light = 5
+local sanc = 6
 
 local pallys = {"holy", "prot", "ret"}
 local available_buffers = {
@@ -202,3 +201,31 @@ assert((assignments[salv] == "prot1" and assignments[kings] == "ret") or (assign
 assert(assignments[wisdom] == "holy2")
 assert(assignments[might] == "holy1")
 assert(assignments[sanc] == "prot2")
+
+pallys = {"holy", "prot"}
+available_buffers = {
+  [wisdom] = {
+    {pallyname = "holy", skill = 9},
+    {pallyname = "prot", skill = 7},
+  },
+  [might] = {
+    {pallyname = "holy", skill = 13},
+    {pallyname = "prot", skill = 8},
+  },
+  [kings] = {},
+  [salv] = {
+    {pallyname = "holy", skill = 1},
+    {pallyname = "prot", skill = 1},
+  },
+  [light] = {
+    {pallyname = "holy", skill = 1},
+    {pallyname = "prot", skill = 1},
+  },
+  [sanc] = {},
+}
+assignments = PallyPowerAutoAssignments(pallys, {sanc, kings, might, wisdom, light}, available_buffers)
+assert(assignments[might] == "holy")
+assert(assignments[wisdom] == "prot")
+assignments = PallyPowerAutoAssignments(pallys, {wisdom, kings, sanc, might, light, salv}, available_buffers)
+assert(assignments[wisdom] == "holy")
+assert(assignments[might] == "prot")

--- a/test_auto_assignments_tbc.lua
+++ b/test_auto_assignments_tbc.lua
@@ -1,0 +1,105 @@
+PallyPower = {isWrath = false}
+
+dofile ("./PallyPowerAutoAssignment.lua")
+
+local kings = PallyPowerAutoAssignmentBuffs.kings
+local sanc = PallyPowerAutoAssignmentBuffs.sanc
+local wisdom = PallyPowerAutoAssignmentBuffs.wisdom
+local might = PallyPowerAutoAssignmentBuffs.might
+local salv = PallyPowerAutoAssignmentBuffs.salv
+local light = PallyPowerAutoAssignmentBuffs.light
+
+local pallys = {"holy", "prot", "ret"}
+local available_buffers = {
+  [wisdom] = {
+    {pallyname = "holy", skill = 9},
+    {pallyname = "prot", skill = 7},
+    {pallyname = "ret", skill = 7},
+  },
+  [might] = {
+    {pallyname = "holy", skill = 13},
+    {pallyname = "prot", skill = 8},
+    {pallyname = "ret", skill = 8},
+  },
+  [kings] = {
+    {pallyname = "holy", skill = 1},
+    {pallyname = "prot", skill = 1},
+    {pallyname = "ret", skill = 1},
+  },
+  [salv] = {
+    {pallyname = "holy", skill = 38},
+    {pallyname = "prot", skill = -17},
+    {pallyname = "ret", skill = -17},
+  },
+  [light] = {
+    {pallyname = "holy", skill = 10},
+    {pallyname = "prot", skill = 1},
+    {pallyname = "ret", skill = 1},
+  },
+  [sanc] = {
+    {pallyname = "prot", skill = 6},
+  },
+}
+
+local assignments = PallyPowerAutoAssignments(pallys, {salv, might, kings, sanc, light}, available_buffers)
+assert(assignments[might] == "holy")
+assert((assignments[salv] == "prot" and assignments[kings] == "ret") or (assignments[kings] == "prot" and assignments[salv] == "ret"))
+
+-- prot pally doesn't have kings anymore
+available_buffers[kings] = {
+  {pallyname = "holy", skill = 1},
+  {pallyname = "ret", skill = 1},
+}
+assignments = PallyPowerAutoAssignments(pallys, {salv, might, kings, sanc, light}, available_buffers)
+assert(assignments[might] == "holy")
+assert(assignments[salv] == "prot" and assignments[kings] == "ret")
+
+pallys = {"prot", "ret"}
+available_buffers = {
+  [wisdom] = {
+    {pallyname = "prot", skill = 7},
+    {pallyname = "ret", skill = 7},
+  },
+  [might] = {
+    {pallyname = "prot", skill = 13},
+    {pallyname = "ret", skill = 8},
+  },
+  [kings] = {
+    {pallyname = "prot", skill = 1},
+  },
+  [salv] = {
+    {pallyname = "prot", skill = 1},
+    {pallyname = "ret", skill = 1},
+  },
+  [light] = {
+    {pallyname = "prot", skill = 1},
+    {pallyname = "ret", skill = 1},
+  },
+  [sanc] = {
+    {pallyname = "prot", skill = 1},
+  },
+}
+
+assignments = PallyPowerAutoAssignments(pallys, {might, kings}, available_buffers)
+assert(assignments[might] == "ret")
+assert(assignments[kings] == "prot")
+assignments = PallyPowerAutoAssignments(pallys, {kings, sanc, might}, available_buffers)
+assert(assignments[kings] == "prot")
+assert(assignments[might] == "ret")
+assert(assignments[sanc] == nil)
+
+pallys = {"prot"}
+assignments = PallyPowerAutoAssignments(pallys, {might, kings}, available_buffers)
+assert(assignments[might] == "prot")
+assignments = PallyPowerAutoAssignments(pallys, {kings, sanc}, available_buffers)
+assert(assignments[kings] == "prot")
+assert(assignments[sanc] == nil)
+assignments = PallyPowerAutoAssignments(pallys, {sanc, kings}, available_buffers)
+assert(assignments[kings] == nil)
+assert(assignments[sanc] == "prot")
+
+pallys = {"prot", "ret"}
+available_buffers[kings] = {{pallyname = "ret", skill = 1}}
+assignments = PallyPowerAutoAssignments(pallys, {kings, sanc}, available_buffers)
+assert(assignments[kings] == "ret")
+assert(assignments[sanc] == "prot")

--- a/test_auto_assignments_wrath.lua
+++ b/test_auto_assignments_wrath.lua
@@ -1,0 +1,47 @@
+PallyPower = {isWrath = true}
+dofile ("./PallyPowerAutoAssignment.lua")
+
+local wisdom = 1
+local might = 2
+local kings = 3
+local sanc = 4
+
+local pallys = {"holy", "prot", "ret"}
+local available_buffers = {
+  [wisdom] = {
+    {pallyname = "holy", skill = 11},
+    {pallyname = "prot", skill = 9},
+    {pallyname = "ret", skill = 9},
+  },
+  [might] = {
+    {pallyname = "holy", skill = 15},
+    {pallyname = "prot", skill = 10},
+    {pallyname = "ret", skill = 10},
+  },
+  [kings] = {
+    {pallyname = "holy", skill = 1},
+    {pallyname = "prot", skill = 1},
+    {pallyname = "ret", skill = 1},
+  },
+  [sanc] = {}
+}
+local assignments = PallyPowerAutoAssignments(pallys, {kings, wisdom, sanc, might}, available_buffers)
+assert(assignments[wisdom] == "holy")
+assert((assignments[might] == "prot" and assignments[kings] == "ret") or (assignments[might] == "ret" and assignments[kings] == "prot"))
+
+pallys[4] = "holy2"
+available_buffers[wisdom][4] = {pallyname = "holy2", skill = 10}
+available_buffers[might][4] = {pallyname = "holy2", skill = 14}
+available_buffers[kings][4] = {pallyname = "holy2", skill = 1}
+available_buffers[sanc][1] = {pallyname = "holy2", skill = 1}
+assignments = PallyPowerAutoAssignments(pallys, {kings, wisdom, sanc, might}, available_buffers)
+assert(assignments[wisdom] == "holy")
+assert((assignments[might] == "prot" and assignments[kings] == "ret") or (assignments[might] == "ret" and assignments[kings] == "prot"))
+assert(assignments[sanc] == "holy2")
+
+available_buffers[wisdom][4].skill = 11
+available_buffers[sanc] = {}
+assignments = PallyPowerAutoAssignments(pallys, {kings, wisdom, sanc, might}, available_buffers)
+assert(assignments[wisdom] == "holy2")
+assert(assignments[might] == "holy")
+assert(assignments[kings] == "prot" or assignments[kings] == "ret")


### PR DESCRIPTION
Updates the auto assignment to be a bit more optimized. In my experience the auto assignment feature isn't used too often because we end up with unoptimized assignments. Or, if it's used at all, it's used to just fill stuff in, and then change to what's ideal. Generally, this change aims to respect the templates in `PallyPowerValues` in group/raid environments with the highest ranks assigned as possible.

For example, if the buff priority is wisdom, might and there are two paladins in the group, with pallyA wisdom = 7, pallyB = 7 and pallyA might = 13, pallyB = 8, if pallyA is evaluated first then they will be assigned wisdom, and pallyB will be assigned might. Ideally in this scenario you'd want pallyA to do might since they have a higher skill, and pallyB on wisdom since they have the baseline skill.

When getting into talented buffs this gets a little messy, but hopefully the result is a step in the right direction 😄. The core changes are in `PallyPowerAutoAssignments.lua` which exposes one function: `PallyPowerAutoAssignments`.

I've been trying this out on TBCC the past couple days, and have logged into the wrath PTR to quickly verify that things work. I've also included some test files (`test_auto_assignments_tbc.lua` and `test_auto_assignments_wrath.lua`) that set up various scenarios with assertions. LMK if there's something I've missed or a test case I should cover.