### PR TITLE
Correct client version in TOC

### DIFF
--- a/PallyPower_Wrath.toc
+++ b/PallyPower_Wrath.toc
@@ -1,4 +1,4 @@
-## Interface: 30402
+## Interface: 30403
 ## Author: Aznamir, Dyaxler, Es, gallantron
 ## Title: PallyPower Classic
 ## Version: @project-version@


### PR DESCRIPTION
Simply changed the Interface version in Wrath TOC to remove out-of-date errors in the game client.