### PR TITLE
Request: (Draft) Add support for Shaman on vanilla cross faction servers

### DIFF
--- a/PallyPowerValues.lua
+++ b/PallyPowerValues.lua
@@ -5,7 +5,8 @@ C_ChatInfo.RegisterAddonMessagePrefix(PallyPower.commPrefix)
 
 PallyPower.petsShareBaseClass = PallyPower.isBCC or PallyPower.isWrath
 
-PALLYPOWER_MAXCLASSES = PallyPower.isWrath and 10 or 9
+--PALLYPOWER_MAXCLASSES = PallyPower.isWrath and 10 or 9
+PALLYPOWER_MAXCLASSES = 10
 PALLYPOWER_MAXPERCLASS = 15
 PALLYPOWER_NORMALBLESSINGDURATION = (PallyPower.isBCC or PallyPower.isWrath) and (10 * 60) or (5 * 60)
 PALLYPOWER_GREATERBLESSINGDURATION = (PallyPower.isBCC or PallyPower.isWrath) and (30 * 60) or (15 * 60)
@@ -163,7 +164,8 @@ PallyPower.ClassID = PallyPower.isWrath and {
 	[6] = "HUNTER",
 	[7] = "MAGE",
 	[8] = "WARLOCK",
-	[9] = "PET"
+	[9] = "SHAMAN",
+	[10] = "PET",
 }
 
 PallyPower.ClassToID = PallyPower.isWrath and {
@@ -196,7 +198,8 @@ PallyPower.ClassToID = PallyPower.isWrath and {
 	["HUNTER"] = 6,
 	["MAGE"] = 7,
 	["WARLOCK"] = 8,
-	["PET"] = 9
+	["SHAMAN"] = 9,
+	["PET"] = 10,
 }
 
 PallyPower.ClassIcons = PallyPower.isWrath and {
@@ -229,7 +232,8 @@ PallyPower.ClassIcons = PallyPower.isWrath and {
 	[6] = "Interface\\Icons\\ClassIcon_Hunter",
 	[7] = "Interface\\Icons\\ClassIcon_Mage",
 	[8] = "Interface\\Icons\\ClassIcon_Warlock",
-	[9] = "Interface\\Icons\\Ability_Mount_JungleTiger"
+	[9] = "Interface\\Icons\\ClassIcon_Shaman",
+	[10] = "Interface\\Icons\\Ability_Mount_JungleTiger",
 }
 
 PallyPower.BlessingIcons = PallyPower.isWrath and {

--- a/PallyPowerValues.lua
+++ b/PallyPowerValues.lua
@@ -5,8 +5,7 @@ C_ChatInfo.RegisterAddonMessagePrefix(PallyPower.commPrefix)
 
 PallyPower.petsShareBaseClass = PallyPower.isBCC or PallyPower.isWrath
 
---PALLYPOWER_MAXCLASSES = PallyPower.isWrath and 10 or 9
-PALLYPOWER_MAXCLASSES = 10
+PALLYPOWER_MAXCLASSES = PallyPower.isBCC and 9 or 10
 PALLYPOWER_MAXPERCLASS = 15
 PALLYPOWER_NORMALBLESSINGDURATION = (PallyPower.isBCC or PallyPower.isWrath) and (10 * 60) or (5 * 60)
 PALLYPOWER_GREATERBLESSINGDURATION = (PallyPower.isBCC or PallyPower.isWrath) and (30 * 60) or (15 * 60)

--- a/PallyPower_Vanilla.xml
+++ b/PallyPower_Vanilla.xml
@@ -1458,12 +1458,21 @@
 					</Anchor>
 				</Anchors>
 			</Button>
+			<Button name = "$parentClass10" inherits = "BuffGridButtonTemplate">
+				<Anchors>
+					<Anchor point = "TOPLEFT" relativeTo = "$parentClass9" relativePoint = "TOPRIGHT">
+						<Offset>
+							<AbsDimension x = "2" y = "0"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+			</Button>
 		</Frames>
 	</Frame>
 
 	<Frame name = "PallyPowerBlessingsFrame" hidden = "true" toplevel = "true" frameStrata = "HIGH" enableMouse = "true" movable = "true" parent = "UIParent">
 		<Size>
-			<AbsDimension x = "1010" y = "1200"/>
+			<AbsDimension x = "1110" y = "1200"/>
 		</Size>
 		<Anchors>
 			<Anchor point = "TOPLEFT" relativeTo = "UIParent" relativePoint = "BOTTOMLEFT">
@@ -1614,6 +1623,15 @@
 			<Frame name = "$parentClassGroup9" inherits = "ClassGroupTemplate">
 				<Anchors>
 					<Anchor point = "TOPLEFT" relativeTo = "$parentClassGroup8" relativePoint = "TOPRIGHT">
+						<Offset>
+							<AbsDimension x = "2" y = "0"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+			</Frame>
+			<Frame name = "$parentClassGroup10" inherits = "ClassGroupTemplate">
+				<Anchors>
+					<Anchor point = "TOPLEFT" relativeTo = "$parentClassGroup9" relativePoint = "TOPRIGHT">
 						<Offset>
 							<AbsDimension x = "2" y = "0"/>
 						</Offset>
@@ -1819,7 +1837,7 @@
 						GameTooltip:Hide(self, motion);
 					</OnLeave>
 				</Scripts>
-			</Button>			
+			</Button>
 			<Button name = "$parentPreset" inherits = "GameMenuButtonTemplate" text = "PALLYPOWER_PRESET" hidden = "false">
 				<Size>
 					<AbsDimension x = "100" y = "20"/>


### PR DESCRIPTION
Private servers are supporting the use of the 1.14.2 client and a proxy to play on the 1.12.1 servers.

Many private servers have a low population and thus allow for cross faction. This makes buffing Shamans cumbersome as they are not tracked by PallyPower. I would like an option to show Shamans in the buff assignment and the tracker.

I read your license that said that no one but you can distribute this addon, so I am reaching out in the hopes that you would add support for shamans, so that I do not violate your license.

I have tried to make a rough PR to simply test if it works, and so far this works alright.
There are some issue with the graphical part of the buff assignment as seen here: 
![pp_shammy](https://github.com/user-attachments/assets/29ec6c63-a0b8-4f08-b266-2d27ebb8c951)

But tracking the buff on the small sidebar works flawlessly.
![pp_shammy_2](https://github.com/user-attachments/assets/3bc21726-eb0b-40fa-8408-b8305b5536e5)

I will leave it up to you if you want shamans to always be available, or if there should be a toggle to decide if they should be shown or not.

I hope you will consider this request.

Best regards
DBFBlackbull