### PR TITLE
Update PallyPower_TBC.toc

### DIFF
--- a/PallyPower_TBC.toc
+++ b/PallyPower_TBC.toc
@@ -1,4 +1,4 @@
-## Interface: 20504
+## Interface: 20505
 ## Author: Aznamir, Dyaxler, Es, gallantron
 ## Title: PallyPower Classic
 ## Version: @project-version@


### PR DESCRIPTION
Correct TBC Anniversary version is 2.5.5. 

https://wago.tools/

<img width="736" height="88" alt="image" src="https://github.com/user-attachments/assets/023de275-5079-426a-8b9c-88c399be0b32" />
